### PR TITLE
fix(workback.rb): SHA was wrong in release 0.1.2

### DIFF
--- a/Formula/workback.rb
+++ b/Formula/workback.rb
@@ -4,7 +4,7 @@ class Workback < Formula
   desc  "An agentic debugging tool that lives in your terminal and helps you debug faster - all through natural language commands."
   homepage "https://hyperdrive.engineering"
   url "https://files.pythonhosted.org/packages/source/w/workback/workback-0.1.2.tar.gz"
-  sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  sha256 "8dca3ac94453aee68b4f79a824618a31d136be921aa14c9101f993d846d8174e"
   license "All rights reserved"
 
   depends_on "python3"


### PR DESCRIPTION
### Description

Fixes SHA weirdly miscalculated in #1 

### Other changes

None.

### Tested

Strange, seems like the same command, but gave me a different SHA.

Before:

```sh
curl -L -s "https://files.pythonhosted.org/packages/source/w/workback/workback-0.1.2.tar.gz" | shasum -a 256
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  -
```

After:

```sh
curl -L -s "https://files.pythonhosted.org/packages/source/w/workback/workback-0.1.2.tar.gz" | shasum -a 256
8dca3ac94453aee68b4f79a824618a31d136be921aa14c9101f993d846d8174e  -
```

### Related issues

Fixes SHA set in #1 

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes.

### Documentation

None.
